### PR TITLE
pom.xml: Fixing issue in successCodes configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,11 @@
 				</executions>
 				 
 				 
-				 <configuration>
-				 <successCodes>0,137</successCodes>
+				<configuration>
+				<successCodes>
+					<successCode>0</successCode>
+					<successCode>137</successCode>
+				</successCodes>
 					<executable>java</executable>
 					<arguments>
 						<argument>-Dlogback.configurationFile=${project.build.directory}/conf/logback.xml</argument>


### PR DESCRIPTION
Hey,

I think the syntax for the pom.xml file changed, due to which I was facing a build error while trying out the framework. I've raised a pull request for fixing this.